### PR TITLE
Aja fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CC=gcc
 CFLAGS=-Wall -Werror -pedantic -std=gnu99 -DSDP_EXTRACTOR_VERSION=\""$(SDP_EXTRACTOR_VERSION)"\"
 EXTRACTOR=sdp_extractor
 LIB_OBJS=sdp_field.o sdp_stream.o sdp_parser.o sdp_log.o smpte2110_sdp_parser.o smpte2022_sdp_parser.o
+LIB_OBJS+=sdp_extractor.o vector.o util.o
 APP_GENERIC_OBJS=util.o
 EXTRACTOR_OBJS=$(APP_GENERIC_OBJS) sdp_extractor.o sdp_extractor_app.o vector.o
 TESTS_OBJS=$(APP_GENERIC_OBJS) sdp_test_util.o sdp_tests.o

--- a/sdp_extractor.c
+++ b/sdp_extractor.c
@@ -774,6 +774,7 @@ static int sdp_parse(struct sdp_extractor *e, void *sdp,
 
 fail:
 	vec_uninit(e->medias);
+	e->medias = NULL;
 	vec_uninit(e->groups);
 	sdp_free_attributes(e->attributes, num_medias);
 	return -1;
@@ -800,10 +801,15 @@ static struct group_member *get_member(struct sdp_extractor *e, int g_idx,
 void sdp_extractor_uninit(sdp_extractor_t sdp_extractor)
 {
 	struct sdp_extractor *e = (struct sdp_extractor*)sdp_extractor;
-	size_t num_medias = vec_size(e->medias);
+	size_t num_medias = 0;
 
 	group_vector_uninit(e->groups);
-	media_vector_uninit(e->medias);
+
+	if (e->medias) {
+		num_medias = vec_size(e->medias);
+		media_vector_uninit(e->medias);
+	}
+
 	sdp_free_attributes(e->attributes, num_medias);
 	if (e->session)
 		sdp_parser_uninit(e->session);

--- a/sdp_extractor.c
+++ b/sdp_extractor.c
@@ -95,6 +95,8 @@ struct media_attribute_video {
 	enum smpte_2110_range range;
 	enum smpte_2110_colorimetry colorimetry;
 	enum smpte_2110_tcs tcs;
+	enum smpte_2110_sampling sampling;
+	enum smpte_2110_depth depth;
 	uint16_t maxudp;
 	struct smpte_2110_par par;
 	uint64_t troff;
@@ -458,6 +460,8 @@ static int extract_2110_20_params(struct sdp_session *session,
 			attributes[i].type.video.maxudp = fmtp_params->maxudp;
 			attributes[i].type.video.troff = fmtp_params->troff;
 			attributes[i].type.video.cmax = fmtp_params->cmax;
+			attributes[i].type.video.sampling = fmtp_params->sampling;
+			attributes[i].type.video.depth = fmtp_params->depth;
 		}
 	}
 
@@ -1071,6 +1075,8 @@ int sdp_extractor_set_2110_20_npackets(sdp_extractor_t sdp_extractor,
 	return extract_stream_params(e, npackets);
 }
 
+SDP_EXTRACTOR_GET(int, -1, 2110_20_depth, type.video.depth)
+SDP_EXTRACTOR_GET(int, -1, 2110_20_sampling, type.video.sampling)
 SDP_EXTRACTOR_GET(int, -1, 2110_20_colorimetry, type.video.colorimetry)
 SDP_EXTRACTOR_GET(int, -1, 2110_20_tcs, type.video.tcs)
 SDP_EXTRACTOR_GET(int, -1, 2110_20_range, type.video.range)

--- a/sdp_extractor.h
+++ b/sdp_extractor.h
@@ -105,6 +105,11 @@ int sdp_extractor_get_2110_20_signal_by_stream(sdp_extractor_t sdp_extractor,
 int sdp_extractor_get_2110_20_signal_by_group(sdp_extractor_t sdp_extractor,
 	int g_idx, int t_idx);
 
+int sdp_extractor_get_2110_20_sampling_by_stream(sdp_extractor_t sdp_extractor,
+	int m_idx);
+int sdp_extractor_get_2110_20_depth_by_stream(sdp_extractor_t sdp_extractor,
+	int m_idx);
+
 int sdp_extractor_get_2110_20_width_by_stream(sdp_extractor_t sdp_extractor,
 	int m_idx);
 int sdp_extractor_get_2110_20_width_by_group(sdp_extractor_t sdp_extractor,

--- a/sdp_extractor_app.c
+++ b/sdp_extractor_app.c
@@ -398,7 +398,7 @@ int main(int argc, char **argv)
 		{ -1, C_ERR("Unknown") },
 	};
 	static struct code2str xfer_characteristic_system[] = {
-		{ TCS_SDR, "SCR" },
+		{ TCS_SDR, "SDR" },
 		{ TCS_PQ, "PQ" },
 		{ TCS_HLG, "HLG" },
 		{ TCS_LINEAR, "LINEAR" },

--- a/sdp_extractor_app.c
+++ b/sdp_extractor_app.c
@@ -353,6 +353,8 @@ int main(int argc, char **argv)
 	int stream_num;
 	int i;
 	int pm;
+	int depth;
+	int sampling;
 	int colorimetry;
 	int tcs;
 	int range;
@@ -383,9 +385,32 @@ int main(int argc, char **argv)
 		{ SIGNAL_PROGRESSIVE, "Progressive" },
 		{ -1, C_ERR("Unknown") }
 	};
+	static struct code2str depths[] = {
+		{ DEPTH_8, "8" },
+		{ DEPTH_10, "10" },
+		{ DEPTH_12, "12" },
+		{ DEPTH_16, "16" },
+		{ DEPTH_16F, "16F" },
+		{ -1, C_ERR("Unknown") }
+	};
 	static struct code2str pms[] = {
 		{ PM_2110GPM, "GPM" },
 		{ PM_2110BPM, "BPM" },
+		{ -1, C_ERR("Unknown") }
+	};
+	static struct code2str samplings[] = {
+		{ SAMPLING_YCbCr_444, "YCbCr_444" },
+		{ SAMPLING_YCbCr_422, "YCbCr_422" },
+		{ SAMPLING_YCbCr_420, "YCbCr_420" },
+		{ SAMPLING_CLYCbCr_444, "CLYCbCr_444" },
+		{ SAMPLING_CLYCbCr_422, "CLYCbCr_422" },
+		{ SAMPLING_CLYCbCr_420, "CLYCbCr_420" },
+		{ SAMPLING_ICtCp_444, "ICtCp_444" },
+		{ SAMPLING_ICtCp_422, "ICtCp_422" },
+		{ SAMPLING_ICtCp_420, "ICtCp_420" },
+		{ SAMPLING_RGB, "RGB" },
+		{ SAMPLING_XYZ, "XYZ" },
+		{ SAMPLING_KEY, "KEY" },
 		{ -1, C_ERR("Unknown") }
 	};
 	static struct code2str colorimetries[] = {
@@ -525,6 +550,16 @@ int main(int argc, char **argv)
 				sdp_extractor, i);
 			stream_printf_ind("packaging mode", "s",
 				code2str(pms, pm));
+
+			sampling = sdp_extractor_get_2110_20_sampling_by_stream(
+				sdp_extractor, i);
+			stream_printf_ind("sampling", "s",
+				code2str(samplings, sampling));
+
+			depth = sdp_extractor_get_2110_20_depth_by_stream(
+				sdp_extractor, i);
+			stream_printf_ind("depth", "s",
+				code2str(depths, depth));
 
 			if (!npackets && pm == PM_2110BPM)
 				npackets =


### PR DESCRIPTION
A small collection of patches to add some missing SMPTE2110-20 attributes, specifically sampling and depth.
Correct a minor typo in the sdp_extractor_app which reported SCR instead of SDR.
Add the sdp_extractor to the library so that third party applications can use it directly.